### PR TITLE
add conditional to show reports menu tab

### DIFF
--- a/app/models/solidus_reports/configuration.rb
+++ b/app/models/solidus_reports/configuration.rb
@@ -2,7 +2,11 @@ module SolidusReports
   class Configuration < Spree::Preferences::Configuration
     REPORT_TABS ||= [:reports]
 
-    new_item = Spree::BackendConfiguration::MenuItem.new(REPORT_TABS, 'file')
+    new_item = Spree::BackendConfiguration::MenuItem.new(
+      REPORT_TABS,
+      'file',
+      condition: -> { can?(:admin, REPORT_TABS) }
+    )
     Spree::Backend::Config.menu_items << new_item
   end
 end

--- a/spec/features/admin/homepage_spec.rb
+++ b/spec/features/admin/homepage_spec.rb
@@ -30,7 +30,7 @@ describe "Homepage", type: :feature do
     it 'should only display tabs fakedispatch has access to' do
       visit spree.admin_path
       expect(page).to have_link('Orders')
-      expect(page).to have_link('Reports')
+      expect(page).not_to have_link('Reports')
       expect(page).not_to have_link('Products')
       expect(page).not_to have_link('Promotions')
       expect(page).not_to have_link('Settings')


### PR DESCRIPTION
This fix to show menu in admin even when user is not logged.