### PR TITLE
Lock SQLite3 to version 1.3

### DIFF
--- a/solidus_reports.gemspec
+++ b/solidus_reports.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '0.49.0'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end


### PR DESCRIPTION
SQLite3 v1.4 was released on February 4th, which breaks compatibility with ActiveRecord's adapter for said DB engine.