### PR TITLE
Fix Reports tab appearing for logged out users

### DIFF
--- a/lib/solidus_reports/configuration.rb
+++ b/lib/solidus_reports/configuration.rb
@@ -2,7 +2,12 @@ module SolidusReports
   class Configuration < Spree::Preferences::Configuration
     REPORT_TABS ||= [:reports]
 
-    new_item = Spree::BackendConfiguration::MenuItem.new(REPORT_TABS, 'file')
+    new_item = Spree::BackendConfiguration::MenuItem.new(
+      REPORT_TABS,
+      'file',
+      condition: -> { current_spree_user && current_spree_user.admin? },
+    )
+
     Spree::Backend::Config.menu_items << new_item
   end
 end


### PR DESCRIPTION
Fixes an issue where the Reports tab would appear for logged out users when the backend login form was being displayed, due to the `MenuItem` instance not having a `:condition`.