### PR TITLE
Update "Installation" docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 Add solidus_reports to your Gemfile:
 
 ```ruby
-gem 'solidus_reports'
+gem 'solidus_reports', github: 'solidusio-contrib/solidus_reports'
 ```
 
 Bundle your dependencies and run the installation generator:


### PR DESCRIPTION
The Installation docs weren't specifying the GitHub gem location. Since
solidus_reports isn't published on rubygems.org, we should specify
Github as gem location.