### PR TITLE
Fixes cancan validation for :reports

### DIFF
--- a/app/models/solidus_reports/configuration.rb
+++ b/app/models/solidus_reports/configuration.rb
@@ -7,7 +7,7 @@ module SolidusReports
     new_item = Spree::BackendConfiguration::MenuItem.new(
       REPORT_TABS,
       'file',
-      condition: -> { can?(:admin, REPORT_TABS) }
+      condition: -> { can?(:admin, :reports) }
     )
     Spree::Backend::Config.menu_items << new_item
   end


### PR DESCRIPTION
Hello. 

I have an issue with `solidus_reports`. The class configuration has an array for the list of tabs within this menu `REPORT_TABS ||= [:reports].freeze`. The cancan validation is `can?(:admin, REPORT_TABS)` . However, I have an admin user with only that permission applied `ReportDisplay` and the menu is not visible. It works for the main admin user though. If I change the cancan validation to `can?(:admin, :reports)` it works for both. I'm not sure if the cancan validation is wrong as it is applied to an array `REPORT_TABS` and not the symbol `:reports` ?. The rest of the solidus core permissions are against a particular class name. This is the only case where the cancan validation is against an array. 

Regards