### PR TITLE
Changes solidus_extension_dev_tools to solidus_dev_support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 inherit_from: .rubocop_todo.yml
 
 require:
-  - solidus_extension_dev_tools/rubocop
+  - solidus_dev_support/rubocop
 
 inherit_gem:
-  solidus_extension_dev_tools: .rubocop.extension.yml
+  solidus_dev_support: .rubocop.extension.yml
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,6 @@ else
 end
 
 gem 'rails-controller-testing', group: :test
-gem 'solidus_extension_dev_tools', github: 'solidusio-contrib/solidus_extension_dev_tools'
+gem 'solidus_dev_support', github: 'solidusio-contrib/solidus_dev_support'
 
 gemspec

--- a/solidus_reports.gemspec
+++ b/solidus_reports.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_support'
 
   s.add_development_dependency 'rspec-activemodel-mocks'
-  s.add_development_dependency 'solidus_extension_dev_tools'
+  s.add_development_dependency 'solidus_dev_support'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,10 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
-require 'solidus_extension_dev_tools/rspec/coverage'
+require 'solidus_dev_support/rspec/coverage'
 
 require File.expand_path('dummy/config/environment.rb', __dir__)
 
-require 'solidus_extension_dev_tools/rspec/feature_helper'
+require 'solidus_dev_support/rspec/feature_helper'
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
Hello

I had some issues with the dependencies of this gem. I changed the `solidus_extension_dev_tools` references for `solidus_dev_support` in order to have the new tools. I know this is a recent change and I'm not sure if this gem was not updated at that time. Without this change it is not possible to run any bundle command or rake task. Regards