### PR TITLE
Test with Ruby 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
   run-specs-with-postgres:
     executor:
       name: solidusio_extensions/postgres
-      ruby_version: '3.1'
+      ruby_version: "3.2"
     steps:
       - checkout
       - browser-tools/install-chrome
@@ -24,7 +24,7 @@ jobs:
   run-specs-with-mysql:
     executor:
       name: solidusio_extensions/mysql
-      ruby_version: '3.0'
+      ruby_version: "3.1"
     steps:
       - checkout
       - browser-tools/install-chrome
@@ -34,7 +34,7 @@ jobs:
   run-specs-with-sqlite:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: '2.7'
+      ruby_version: "3.0"
     steps:
       - checkout
       - browser-tools/install-chrome

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'rails', '>0.a'
 
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
+gem 'solidus_dev_support'
 
 case ENV['DB']
 when 'mysql'
@@ -29,6 +30,9 @@ else
   gem 'sqlite3'
 end
 
-gem 'rails-controller-testing', group: :test
+group :test do
+  gem 'rails-controller-testing'
+  gem 'rspec-activemodel-mocks'
+end
 
 gemspec

--- a/solidus_reports.gemspec
+++ b/solidus_reports.gemspec
@@ -31,7 +31,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency "solidus_core", [">= 2.5", "< 4.0"]
   s.add_dependency "solidus_support", "~> 0.5"
-
-  s.add_development_dependency "rspec-activemodel-mocks"
-  s.add_development_dependency "solidus_dev_support"
 end

--- a/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Spree::Admin::ReportsController, type: :controller do
+describe Spree::Admin::ReportsController do
   stub_authorization!
 
   after do

--- a/spec/features/admin/homepage_spec.rb
+++ b/spec/features/admin/homepage_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe "Homepage", type: :feature do
+describe "Homepage" do
   context 'as admin user' do
     stub_authorization!
 


### PR DESCRIPTION
This gem claims to support Ruby 3.2, but does not run tests for it. Let's drop 2.7 tests, as this Ruby is EOL anyway.