### PR TITLE
Fix how we setup config

### DIFF
--- a/lib/solidus_reports/configuration.rb
+++ b/lib/solidus_reports/configuration.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+require "spree/preferences/configuration"
+
 module SolidusReports
   class Configuration < Spree::Preferences::Configuration
     REPORT_TABS ||= [:reports].freeze
 
     new_item = Spree::BackendConfiguration::MenuItem.new(
       REPORT_TABS,
-      'file',
-      condition: -> { can?(:admin, :reports) }
+      "file",
+      condition: -> { can?(:admin, :reports) },
     )
     Spree::Backend::Config.menu_items << new_item
   end

--- a/lib/solidus_reports/engine.rb
+++ b/lib/solidus_reports/engine.rb
@@ -16,7 +16,7 @@ module SolidusReports
     end
 
     initializer "solidus_reports.environment", before: :load_config_initializers do
-      require_dependency "solidus_reports/configuration"
+      require "solidus_reports/configuration"
       SolidusReports::Config = SolidusReports::Configuration.new
     end
   end


### PR DESCRIPTION
Require the config instead of relying on autoloading. Using autoloaded constants in initializers is deprecated in Rails.