### PR TITLE
Fix deprecated MenuItem arguments

### DIFF
--- a/lib/solidus_reports/engine.rb
+++ b/lib/solidus_reports/engine.rb
@@ -17,15 +17,9 @@ module SolidusReports
     end
 
     initializer "solidus_reports.environment", before: :load_config_initializers do
-      # rubocop:disable Lint/ConstantDefinitionInBlock
-      # rubocop:disable Lint/OrAssignmentToConstant
-      REPORT_TABS ||= [:reports].freeze
-      # rubocop:enable Lint/ConstantDefinitionInBlock
-      # rubocop:enable Lint/OrAssignmentToConstant
-
       new_item = Spree::BackendConfiguration::MenuItem.new(
-        REPORT_TABS,
-        "file",
+        label: :reports,
+        icon: "file",
         condition: -> { can?(:admin, :reports) }
       )
       Spree::Backend::Config.menu_items << new_item


### PR DESCRIPTION
Spree::BackendConfiguration::MenuItem no longer accepts the positional `sections` and `icon` arguments; `sections` is replaced by a `label:` keyword and `icon` must be passed as a keyword. Pass `label: :reports` and `icon: "file"` instead, which removes two deprecation warnings on boot.

The REPORT_TABS constant was only used to supply the (now removed) positional sections argument, so inline `:reports` and drop the constant.